### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,9 @@
 
 name: Test and build
 
+permissions:
+    contents: read
+
 on:
     pull_request:
         branches: ['main']


### PR DESCRIPTION
Potential fix for [https://github.com/remi-espie/remi-espie/security/code-scanning/2](https://github.com/remi-espie/remi-espie/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the root level of the workflow file. Since the workflow only performs read operations (e.g., checking out the code, installing dependencies, and running tests), we will set `contents: read` as the minimal required permission. This ensures that the `GITHUB_TOKEN` is restricted to read-only access to the repository contents.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
